### PR TITLE
Adding users, tokens, validations and /auth endpoint along with admin…

### DIFF
--- a/cmd/api/coffeeHandlers.go
+++ b/cmd/api/coffeeHandlers.go
@@ -3,13 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
 	"cmsc.group2.coffee-api/internal/dataModels"
-	"cmsc.group2.coffee-api/internal/validation"
 	"github.com/julienschmidt/httprouter"
 )
 
@@ -131,65 +129,65 @@ func (app *application) coffeeDetails(w http.ResponseWriter, r *http.Request) {
 }
 
 // TODO: This needs a little work
-func (app *application) newCoffee(w http.ResponseWriter, r *http.Request) {
-	// We expect a content-type of application/json for this request
-	if r.Header.Get("Content-Type") != "application/json" {
-		app.logger.Error("Content-Type is not application/json")
-		http.Error(w, "Content-Type header is not application/json", http.StatusBadRequest)
-		return
-	}
+// func (app *application) newCoffee(w http.ResponseWriter, r *http.Request) {
+// 	// We expect a content-type of application/json for this request
+// 	if r.Header.Get("Content-Type") != "application/json" {
+// 		app.logger.Error("Content-Type is not application/json")
+// 		http.Error(w, "Content-Type header is not application/json", http.StatusBadRequest)
+// 		return
+// 	}
 
-	var newCoffee dataModels.Coffee
-	err := json.NewDecoder(r.Body).Decode(&newCoffee)
-	if err != nil {
-		app.logger.Error("decode json", err)
-		http.Error(w, "Error decoding JSON body", http.StatusBadRequest)
-		return
-	}
+// 	var newCoffee dataModels.Coffee
+// 	err := json.NewDecoder(r.Body).Decode(&newCoffee)
+// 	if err != nil {
+// 		app.logger.Error("decode json", err)
+// 		http.Error(w, "Error decoding JSON body", http.StatusBadRequest)
+// 		return
+// 	}
 
-	// Call the ValidateCoffee function from the validation package
-	err = validation.ValidateCoffee(&newCoffee)
-	if err != nil {
-		// Handle validation errors
-		app.errorJSON(w, err, http.StatusBadRequest)
-		return
-	}
+// 	// Call the ValidateCoffee function from the validation package
+// 	err = validation.ValidateCoffee(&newCoffee)
+// 	if err != nil {
+// 		// Handle validation errors
+// 		app.errorJSON(w, err, http.StatusBadRequest)
+// 		return
+// 	}
 
-	// Define a timeout for the database operation
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
+// 	// Define a timeout for the database operation
+// 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+// 	defer cancel()
 
-	// Insert the coffee into the database
-	err = newCoffee.AddCoffee(ctx, app.db)
-	if err != nil {
-		app.logger.Error("inserting coffee", err)
-		http.Error(w, "Server error", http.StatusInternalServerError)
-		return
-	}
+// 	// Insert the coffee into the database
+// 	err = newCoffee.AddCoffee(ctx, app.db)
+// 	if err != nil {
+// 		app.logger.Error("inserting coffee", err)
+// 		http.Error(w, "Server error", http.StatusInternalServerError)
+// 		return
+// 	}
 
-	// Respond to the client with the ID of the new coffee
-	w.Header().Set("Location", fmt.Sprintf("/coffee/%d", newCoffee.ID))
-	w.WriteHeader(http.StatusCreated)
-	// Optionally return the new coffee object in the response
-	js, _ := json.Marshal(newCoffee)
-	w.Write(js)
-}
+// 	// Respond to the client with the ID of the new coffee
+// 	w.Header().Set("Location", fmt.Sprintf("/coffee/%d", newCoffee.ID))
+// 	w.WriteHeader(http.StatusCreated)
+// 	// Optionally return the new coffee object in the response
+// 	js, _ := json.Marshal(newCoffee)
+// 	w.Write(js)
+// }
 
-func (app *application) errorJSON(w http.ResponseWriter, err error, status ...int) {
-	statusCode := http.StatusBadRequest
-	if len(status) > 0 {
-		statusCode = status[0]
-	}
+// func (app *application) errorJSON(w http.ResponseWriter, err error, status ...int) {
+// 	statusCode := http.StatusBadRequest
+// 	if len(status) > 0 {
+// 		statusCode = status[0]
+// 	}
 
-	type jsonError struct {
-		Message string `json:"message"`
-	}
+// 	type jsonError struct {
+// 		Message string `json:"message"`
+// 	}
 
-	theError := jsonError{
-		Message: err.Error(),
-	}
+// 	theError := jsonError{
+// 		Message: err.Error(),
+// 	}
 
-	w.WriteHeader(statusCode)
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(theError)
-}
+// 	w.WriteHeader(statusCode)
+// 	w.Header().Set("Content-Type", "application/json")
+// 	json.NewEncoder(w).Encode(theError)
+// }

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (app *application) readJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	err := json.NewDecoder(r.Body).Decode(&dst)
+	if err != nil {
+		var syntaxError *json.SyntaxError
+		var unmarshalTypeError *json.UnmarshalTypeError
+		var invalidUnmarshalError *json.InvalidUnmarshalError
+		switch {
+		case errors.As(err, &syntaxError):
+			return fmt.Errorf("body contains incorrect JSON syntax (at character %d)", syntaxError.Offset)
+
+		case errors.Is(err, io.ErrUnexpectedEOF):
+			return errors.New("body contains incorrect JSON syntax")
+		case errors.As(err, &unmarshalTypeError):
+			if unmarshalTypeError.Field != "" {
+				return fmt.Errorf("body contains incorret JSON type for field %q", unmarshalTypeError.Field)
+			}
+			return fmt.Errorf("body contains incorrect JSON type (at character %d)", unmarshalTypeError.Offset)
+		case errors.Is(err, io.EOF):
+			return errors.New("body must not be empty")
+
+		case errors.As(err, &invalidUnmarshalError):
+			panic(err)
+		default:
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -14,13 +14,14 @@ func (app *application) Routes() *httprouter.Router {
 	router.Handler(http.MethodGet, "/coffee", app.sessionManager.LoadAndSave(http.HandlerFunc(app.coffees)))
 	router.Handler(http.MethodGet, "/coffee/:id", app.sessionManager.LoadAndSave(http.HandlerFunc(app.coffeeDetails)))
 	// Add middleware to the below endpoints to validate authToken
-	router.Handler(http.MethodPost, "/coffee", http.HandlerFunc(app.newCoffee))
+	// router.Handler(http.MethodPost, "/coffee", http.HandlerFunc(app.newCoffee))
 
 	router.Handler(http.MethodPost, "/cart/:id", app.sessionManager.LoadAndSave(http.HandlerFunc(app.addCoffee)))
 	router.Handler(http.MethodDelete, "/cart/:id", app.sessionManager.LoadAndSave(http.HandlerFunc(app.removeCoffee)))
 	router.Handler(http.MethodGet, "/cart", app.sessionManager.LoadAndSave(http.HandlerFunc(app.shoppingCart)))
 
-	router.Handler(http.MethodPost, "/auth", app.sessionManager.LoadAndSave(http.HandlerFunc(app.auth)))
+	// Generate a new authentication token for admin usage
+	router.Handler(http.MethodPost, "/auth", http.HandlerFunc(app.createAuthToken))
 
 	// Liveness is used by kubernetes
 	router.HandlerFunc(http.MethodGet, "/liveness", app.liveness)

--- a/cmd/api/tokens.go
+++ b/cmd/api/tokens.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"cmsc.group2.coffee-api/internal/dataModels"
+	"cmsc.group2.coffee-api/internal/validation"
+)
+
+func (app *application) createAuthToken(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	err := app.readJSON(w, r, &input)
+	if err != nil {
+		app.logger.Error("decode json", err)
+		http.Error(w, "Error decoding JSON body", http.StatusBadRequest)
+		return
+	}
+	v := validation.New()
+
+	dataModels.ValidateEmail(v, input.Email)
+	dataModels.ValidatePasswordPlaintext(v, input.Password)
+
+	if !v.Valid() {
+		app.logger.Error("validation failed")
+		http.Error(w, "Authentication failure", http.StatusUnauthorized)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	user, err := dataModels.GetByEmail(ctx, app.db, input.Email)
+
+	if err != nil {
+		app.logger.Error("User account not found", err)
+		http.Error(w, "Authentication failure", http.StatusUnauthorized)
+		return
+	}
+
+	match, err := user.Password.Matches(input.Password)
+	if err != nil {
+		app.logger.Error("Account mismatch", err)
+		http.Error(w, "Authentication failure", http.StatusUnauthorized)
+		return
+	}
+
+	if !match {
+		http.Error(w, "Authentication failure", http.StatusUnauthorized)
+	}
+
+	// If password is correct, we issue the token
+	token, err := dataModels.New(app.db, user.ID, 4*time.Hour, dataModels.ScopeAuthentication)
+	if err != nil {
+		app.logger.Error("Error from New Token creation", err)
+		http.Error(w, "error processing", http.StatusInternalServerError)
+		return
+	}
+	js, err := json.Marshal(token)
+	if err != nil {
+		app.logger.Error("marshal json", err)
+		http.Error(w, "Server error", http.StatusInternalServerError)
+		return
+	}
+	// Write response to http.ResponseWriter
+	js = append(js, '\n')
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}

--- a/cmd/tooling/cmd/adminPwd.go
+++ b/cmd/tooling/cmd/adminPwd.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"flag"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func CreateAdminPassword() ([]byte, error) {
+	// Read the password from command line.
+	pwd := flag.String("password", "password123$", "Use this to pass in a unique password")
+	flag.Parse()
+	hash, err := bcrypt.GenerateFromPassword([]byte(*pwd), 12)
+	if err != nil {
+		return nil, err
+	}
+	return hash, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,26 +6,18 @@ require (
 	github.com/alexedwards/scs/pgxstore v0.0.0-20240203174419-a38e822451b6
 	github.com/alexedwards/scs/v2 v2.7.0
 	github.com/ardanlabs/darwin v1.5.0
-	github.com/go-playground/validator/v10 v10.18.0
 	github.com/jackc/pgx/v5 v5.5.3
 	github.com/julienschmidt/httprouter v1.3.0
 )
 
-require (
-	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/leodido/go-urn v1.4.0 // indirect
-	golang.org/x/net v0.21.0 // indirect
-	golang.org/x/sys v0.17.0 // indirect
-)
+require github.com/stretchr/testify v1.8.4 // indirect
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
-	golang.org/x/crypto v0.19.0 // indirect
+	golang.org/x/crypto v0.19.0
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,16 +13,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
-github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
-github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
-github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
-github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
-github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
-github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
-github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
-github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.18.0 h1:BvolUXjp4zuvkZ5YN5t7ebzbhlUtPsPm2S9NAZ5nl9U=
-github.com/go-playground/validator/v10 v10.18.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -44,8 +34,6 @@ github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NB
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
-github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -74,8 +62,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
-golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=

--- a/internal/dataModels/coffee.go
+++ b/internal/dataModels/coffee.go
@@ -16,9 +16,6 @@ type Coffee struct {
 	Calories    int     `db:"coffee_calories" json:"calories,omitempty"`
 }
 
-// Slice of Coffees
-// type Coffees []Coffee
-
 func (c *Coffee) AddCoffee(ctx context.Context, db *pgxpool.Pool) error {
 	const stmt = `INSERT INTO coffee (coffee_name, coffee_description, coffee_price, coffee_caffeine, coffee_calories) VALUES ($1, $2, $3, $4, $5) RETURNING coffee_id`
 	return db.QueryRow(ctx, stmt, c.Name, c.Description, c.Price, c.Caffeine, c.Calories).Scan(&c.ID)

--- a/internal/dataModels/tokens.go
+++ b/internal/dataModels/tokens.go
@@ -1,0 +1,67 @@
+package dataModels
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base32"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	ScopeAuthentication = "authentication"
+)
+
+type Token struct {
+	Plaintext string    `json:"token"`
+	Hash      []byte    `json:"-"`
+	UserID    int64     `json:"-"`
+	Expiry    time.Time `json:"expiry"`
+	Scope     string    `json:"-"`
+}
+
+func New(db *pgxpool.Pool, userID int64, ttl time.Duration, scope string) (*Token, error) {
+	token, err := generateToken(userID, ttl, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	query := `
+	INSERT INTO tokens (hash, user_id, expiry, scope) 
+	VALUES ($1, $2, $3, $4)`
+
+	args := []any{token.Hash, token.UserID, token.Expiry, token.Scope}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err = db.Exec(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return token, err
+}
+
+func generateToken(userID int64, ttl time.Duration, scope string) (*Token, error) {
+	token := &Token{
+		UserID: userID,
+		Expiry: time.Now().Add(ttl),
+		Scope:  scope,
+	}
+
+	randomBytes := make([]byte, 16)
+
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	token.Plaintext = base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(randomBytes)
+
+	hash := sha256.Sum256([]byte(token.Plaintext))
+	token.Hash = hash[:]
+
+	return token, nil
+}

--- a/internal/dataModels/users.go
+++ b/internal/dataModels/users.go
@@ -1,0 +1,92 @@
+package dataModels
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"cmsc.group2.coffee-api/internal/validation"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/crypto/bcrypt"
+)
+
+var AnonymousUser = &User{}
+
+type User struct {
+	ID        int64     `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	Name      string    `json:"name"`
+	Email     string    `json:"email"`
+	Password  password  `json:"-"`
+}
+
+type password struct {
+	plaintext *string
+	hash      []byte
+}
+
+func (p *password) Set(plaintextPassword string) error {
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintextPassword), 12)
+	if err != nil {
+		return err
+	}
+
+	p.plaintext = &plaintextPassword
+	p.hash = hash
+
+	return nil
+}
+
+func (p *password) Matches(plaintextPassword string) (bool, error) {
+	err := bcrypt.CompareHashAndPassword(p.hash, []byte(plaintextPassword))
+	if err != nil {
+		switch {
+		case errors.Is(err, bcrypt.ErrMismatchedHashAndPassword):
+			return false, nil
+		default:
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (u *User) IsAnonymous() bool {
+	return u == AnonymousUser
+}
+
+func ValidateEmail(v *validation.Validator, email string) {
+	v.Check(email != "", "email", "must be provided")
+	v.Check(validation.Matches(email, validation.EmailRX), "email", "must be a valid email address")
+}
+
+func ValidatePasswordPlaintext(v *validation.Validator, password string) {
+	v.Check(password != "", "password", "must be provided")
+	v.Check(len(password) >= 8, "password", "must be at least 8 bytes long")
+	v.Check(len(password) <= 72, "password", "must not be more than 72 bytes long")
+}
+
+func GetByEmail(ctx context.Context, db *pgxpool.Pool, email string) (*User, error) {
+	query := `
+        SELECT id, created_at, name, email, password_hash
+        FROM users
+        WHERE email = $1`
+
+	var user User
+
+	// ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// defer cancel()
+
+	err := db.QueryRow(ctx, query, email).Scan(
+		&user.ID,
+		&user.CreatedAt,
+		&user.Name,
+		&user.Email,
+		&user.Password.hash,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}

--- a/internal/schema/sql/schema.sql
+++ b/internal/schema/sql/schema.sql
@@ -10,7 +10,7 @@ CREATE TABLE sessions (
 CREATE INDEX sessions_expiry_idx ON sessions (expiry);
 
 -- Version: 1.2
--- Description: Coffee products, represent price with [S,M,L,X]
+-- Description: Coffee products
 CREATE TABLE coffee (
 	coffee_id INT GENERATED ALWAYS AS IDENTITY,
 	coffee_name TEXT,
@@ -22,16 +22,23 @@ CREATE TABLE coffee (
 );
 
 -- Version: 1.3
--- Description: Cart will map to session token. 
--- Each cart will contain user session and coffees added.
--- If session is deleted, cart will also be deleted.
--- CREATE TABLE shoppingcart (
--- 	cart_id INT GENERATED ALWAYS AS IDENTITY,
--- 	sessions_token TEXT,
--- 	customs_coffees_id INT,
--- 	PRIMARY KEY (cart_id),
--- 	CONSTRAINT fk_session
--- 		FOREIGN KEY(sessions_token)
--- 			REFERENCES sessions(token)
--- 			ON DELETE CASCADE
--- );
+-- Description: Create User table, used for only admin currently
+CREATE EXTENSION citext;
+
+CREATE TABLE users (
+id bigserial PRIMARY KEY,
+created_at timestamp(0) with time zone NOT NULL DEFAULT NOW(), 
+name text NOT NULL,
+email citext UNIQUE NOT NULL,
+password_hash bytea NOT NULL
+);
+
+-- Version: 1.4
+-- Description: Create Tokens for the privileged actions
+CREATE TABLE tokens (
+hash bytea PRIMARY KEY,
+user_id bigint NOT NULL REFERENCES users ON DELETE CASCADE, 
+expiry timestamp(0) with time zone NOT NULL,
+scope text NOT NULL
+);
+

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -1,14 +1,56 @@
 package validation
 
 import (
-	"cmsc.group2.coffee-api/internal/dataModels"
-	"github.com/go-playground/validator/v10"
+	"regexp"
+	"slices"
 )
 
-// Initialize a validator instance
-var validate = validator.New()
+var (
+	EmailRX = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+)
 
-func ValidateCoffee(coffee *dataModels.Coffee) error {
-	// Perform validation and return any errors
-	return validate.Struct(coffee)
+type Validator struct {
+	Errors map[string]string
 }
+
+func New() *Validator {
+	return &Validator{Errors: make(map[string]string)}
+}
+
+// Valid returns true if the errors map has no entries
+func (v *Validator) Valid() bool {
+	return len(v.Errors) == 0
+}
+
+func (v *Validator) AddError(key, message string) {
+	if _, exists := v.Errors[key]; !exists {
+		v.Errors[key] = message
+	}
+}
+
+func (v *Validator) Check(ok bool, key, message string) {
+	if !ok {
+		v.AddError(key, message)
+	}
+}
+
+func PermittedValue[T comparable](value T, permittedValues ...T) bool {
+	return slices.Contains(permittedValues, value)
+}
+
+func Matches(value string, rx *regexp.Regexp) bool {
+	return rx.MatchString(value)
+}
+
+func Unique[T comparable](values []T) bool {
+	uniqueValues := make(map[T]bool)
+	for _, value := range values {
+		uniqueValues[value] = true
+	}
+	return len(values) == len(uniqueValues)
+}
+
+// func ValidateCoffee(coffee *dataModels.Coffee) error {
+// 	// Perform validation and return any errors
+// 	return validate.Struct(coffee)
+// }


### PR DESCRIPTION
This adds the /auth endpoint and all surrounding database methods and handler functions. User and Tokens were thusly added to the dataModels package, validations were changed slightly so we can validate emails as well based on some criteria. This endpoint will return a user token for a default (already seeded) admin based on email admin@coffeeshop.com and password password123$.